### PR TITLE
Allow installing on PHP 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.1",
         "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0",
         "illuminate/http": "5.6.*|5.7.*|5.8.*|^6.0",
         "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0",


### PR DESCRIPTION
The newer versions of the original package that do support PHP 8.x are not installable on Laravel 6.x, as they require `symfony/var-dumper:"^5.0|^6.0"` while `laravel/framework` requires `symfony/var-dumper:^4.3.4`.

This allows retaining the custom dumper functionality on Laravel 6 on PHP 8.0